### PR TITLE
rm cosigner default value

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensor-foundation/marketplace",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Your one-stop-shop for your NFT needs.",
   "sideEffects": false,
   "module": "./dist/src/index.mjs",

--- a/clients/js/src/generated/instructions/buyCompressed.ts
+++ b/clients/js/src/generated/instructions/buyCompressed.ts
@@ -88,9 +88,7 @@ export type BuyCompressedInstruction<
   TAccountTakerBroker extends string | IAccountMeta<string> = string,
   TAccountMakerBroker extends string | IAccountMeta<string> = string,
   TAccountRentDestination extends string | IAccountMeta<string> = string,
-  TAccountCosigner extends
-    | string
-    | IAccountMeta<string> = 'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp',
+  TAccountCosigner extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
   IInstructionWithData<Uint8Array> &
@@ -422,10 +420,6 @@ export async function getBuyCompressedInstructionAsync<
   if (!accounts.rentDestination.value) {
     accounts.rentDestination.value = expectSome(accounts.owner.value);
   }
-  if (!accounts.cosigner.value) {
-    accounts.cosigner.value =
-      'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp' as Address<'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp'>;
-  }
   if (!args.nonce) {
     args.nonce = expectSome(args.index);
   }
@@ -666,10 +660,6 @@ export function getBuyCompressedInstruction<
   }
   if (!accounts.rentDestination.value) {
     accounts.rentDestination.value = expectSome(accounts.owner.value);
-  }
-  if (!accounts.cosigner.value) {
-    accounts.cosigner.value =
-      'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp' as Address<'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp'>;
   }
   if (!args.nonce) {
     args.nonce = expectSome(args.index);

--- a/clients/js/src/generated/instructions/buyCore.ts
+++ b/clients/js/src/generated/instructions/buyCore.ts
@@ -66,9 +66,7 @@ export type BuyCoreInstruction<
   TAccountSystemProgram extends
     | string
     | IAccountMeta<string> = '11111111111111111111111111111111',
-  TAccountCosigner extends
-    | string
-    | IAccountMeta<string> = 'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp',
+  TAccountCosigner extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
   IInstructionWithData<Uint8Array> &
@@ -310,10 +308,6 @@ export async function getBuyCoreInstructionAsync<
     accounts.systemProgram.value =
       '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
   }
-  if (!accounts.cosigner.value) {
-    accounts.cosigner.value =
-      'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp' as Address<'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp'>;
-  }
 
   // Remaining accounts.
   const remainingAccounts: IAccountMeta[] = (args.creators ?? []).map(
@@ -498,10 +492,6 @@ export function getBuyCoreInstruction<
   if (!accounts.systemProgram.value) {
     accounts.systemProgram.value =
       '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
-  }
-  if (!accounts.cosigner.value) {
-    accounts.cosigner.value =
-      'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp' as Address<'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp'>;
   }
 
   // Remaining accounts.

--- a/clients/js/src/generated/instructions/buyLegacy.ts
+++ b/clients/js/src/generated/instructions/buyLegacy.ts
@@ -106,9 +106,7 @@ export type BuyLegacyInstruction<
     | IAccountMeta<string> = string,
   TAccountTokenMetadataProgram extends string | IAccountMeta<string> = string,
   TAccountSysvarInstructions extends string | IAccountMeta<string> = string,
-  TAccountCosigner extends
-    | string
-    | IAccountMeta<string> = 'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp',
+  TAccountCosigner extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
   IInstructionWithData<Uint8Array> &
@@ -541,10 +539,6 @@ export async function getBuyLegacyInstructionAsync<
       ...resolveSysvarInstructionsFromTokenStandard(resolverScope),
     };
   }
-  if (!accounts.cosigner.value) {
-    accounts.cosigner.value =
-      'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp' as Address<'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp'>;
-  }
 
   // Remaining accounts.
   const remainingAccounts: IAccountMeta[] = (args.creators ?? []).map(
@@ -858,10 +852,6 @@ export function getBuyLegacyInstruction<
       ...accounts.sysvarInstructions,
       ...resolveSysvarInstructionsFromTokenStandard(resolverScope),
     };
-  }
-  if (!accounts.cosigner.value) {
-    accounts.cosigner.value =
-      'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp' as Address<'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp'>;
   }
 
   // Remaining accounts.

--- a/clients/js/src/generated/instructions/buySplCompressed.ts
+++ b/clients/js/src/generated/instructions/buySplCompressed.ts
@@ -99,9 +99,7 @@ export type BuySplCompressedInstruction<
   TAccountMakerBrokerCurrencyTa extends string | IAccountMeta<string> = string,
   TAccountRentDestination extends string | IAccountMeta<string> = string,
   TAccountRentPayer extends string | IAccountMeta<string> = string,
-  TAccountCosigner extends
-    | string
-    | IAccountMeta<string> = 'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp',
+  TAccountCosigner extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
   IInstructionWithData<Uint8Array> &
@@ -523,10 +521,6 @@ export async function getBuySplCompressedInstructionAsync<
   if (!accounts.rentDestination.value) {
     accounts.rentDestination.value = expectSome(accounts.owner.value);
   }
-  if (!accounts.cosigner.value) {
-    accounts.cosigner.value =
-      'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp' as Address<'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp'>;
-  }
   if (!args.nonce) {
     args.nonce = expectSome(args.index);
   }
@@ -837,10 +831,6 @@ export function getBuySplCompressedInstruction<
   }
   if (!accounts.rentDestination.value) {
     accounts.rentDestination.value = expectSome(accounts.owner.value);
-  }
-  if (!accounts.cosigner.value) {
-    accounts.cosigner.value =
-      'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp' as Address<'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp'>;
   }
   if (!args.nonce) {
     args.nonce = expectSome(args.index);

--- a/clients/js/src/generated/instructions/buyWns.ts
+++ b/clients/js/src/generated/instructions/buyWns.ts
@@ -86,9 +86,7 @@ export type BuyWnsInstruction<
     | string
     | IAccountMeta<string> = 'diste3nXmK7ddDTs1zb6uday6j4etCa9RChD8fJ1xay',
   TAccountExtraMetas extends string | IAccountMeta<string> = string,
-  TAccountCosigner extends
-    | string
-    | IAccountMeta<string> = 'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp',
+  TAccountCosigner extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
   IInstructionWithData<Uint8Array> &
@@ -452,10 +450,6 @@ export async function getBuyWnsInstructionAsync<
       ...(await resolveWnsExtraAccountMetasPda(resolverScope)),
     };
   }
-  if (!accounts.cosigner.value) {
-    accounts.cosigner.value =
-      'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp' as Address<'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp'>;
-  }
 
   // Remaining accounts.
   const remainingAccounts: IAccountMeta[] = (args.creators ?? []).map(
@@ -720,10 +714,6 @@ export function getBuyWnsInstruction<
   if (!accounts.distributionProgram.value) {
     accounts.distributionProgram.value =
       'diste3nXmK7ddDTs1zb6uday6j4etCa9RChD8fJ1xay' as Address<'diste3nXmK7ddDTs1zb6uday6j4etCa9RChD8fJ1xay'>;
-  }
-  if (!accounts.cosigner.value) {
-    accounts.cosigner.value =
-      'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp' as Address<'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp'>;
   }
 
   // Remaining accounts.

--- a/clients/js/src/generated/instructions/listCompressed.ts
+++ b/clients/js/src/generated/instructions/listCompressed.ts
@@ -77,9 +77,7 @@ export type ListCompressedInstruction<
     | IAccountMeta<string> = 'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp',
   TAccountListState extends string | IAccountMeta<string> = string,
   TAccountRentPayer extends string | IAccountMeta<string> = string,
-  TAccountCosigner extends
-    | string
-    | IAccountMeta<string> = 'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp',
+  TAccountCosigner extends string | IAccountMeta<string> = string,
   TRemainingAccounts extends readonly IAccountMeta<string>[] = [],
 > = IInstruction<TProgram> &
   IInstructionWithData<Uint8Array> &
@@ -377,10 +375,6 @@ export async function getListCompressedInstructionAsync<
       ...resolveRemainingSignerWithOwnerOrDelegate(resolverScope),
     };
   }
-  if (!accounts.cosigner.value) {
-    accounts.cosigner.value =
-      'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp' as Address<'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp'>;
-  }
   if (!args.nonce) {
     args.nonce = expectSome(args.index);
   }
@@ -594,10 +588,6 @@ export function getListCompressedInstruction<
       ...accounts.rentPayer,
       ...resolveRemainingSignerWithOwnerOrDelegate(resolverScope),
     };
-  }
-  if (!accounts.cosigner.value) {
-    accounts.cosigner.value =
-      'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp' as Address<'TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp'>;
   }
   if (!args.nonce) {
     args.nonce = expectSome(args.index);

--- a/clients/rust/src/generated/instructions/buy_compressed.rs
+++ b/clients/rust/src/generated/instructions/buy_compressed.rs
@@ -203,7 +203,7 @@ pub struct BuyCompressedInstructionArgs {
 ///   12. `[writable, optional]` taker_broker
 ///   13. `[writable, optional]` maker_broker
 ///   14. `[writable]` rent_destination
-///   15. `[signer, optional]` cosigner (default to `TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp`)
+///   15. `[signer, optional]` cosigner
 #[derive(Clone, Debug, Default)]
 pub struct BuyCompressedBuilder {
     fee_vault: Option<solana_program::pubkey::Pubkey>,

--- a/clients/rust/src/generated/instructions/buy_core.rs
+++ b/clients/rust/src/generated/instructions/buy_core.rs
@@ -186,7 +186,7 @@ pub struct BuyCoreInstructionArgs {
 ///   10. `[optional]` mpl_core_program (default to `CoREENxT6tW1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d`)
 ///   11. `[optional]` marketplace_program (default to `TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp`)
 ///   12. `[optional]` system_program (default to `11111111111111111111111111111111`)
-///   13. `[signer, optional]` cosigner (default to `TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp`)
+///   13. `[signer, optional]` cosigner
 #[derive(Clone, Debug, Default)]
 pub struct BuyCoreBuilder {
     fee_vault: Option<solana_program::pubkey::Pubkey>,

--- a/clients/rust/src/generated/instructions/buy_legacy.rs
+++ b/clients/rust/src/generated/instructions/buy_legacy.rs
@@ -295,7 +295,7 @@ pub struct BuyLegacyInstructionArgs {
 ///   20. `[optional]` authorization_rules_program
 ///   21. `[optional]` token_metadata_program
 ///   22. `[optional]` sysvar_instructions
-///   23. `[signer, optional]` cosigner (default to `TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp`)
+///   23. `[signer, optional]` cosigner
 #[derive(Clone, Debug, Default)]
 pub struct BuyLegacyBuilder {
     fee_vault: Option<solana_program::pubkey::Pubkey>,

--- a/clients/rust/src/generated/instructions/buy_spl_compressed.rs
+++ b/clients/rust/src/generated/instructions/buy_spl_compressed.rs
@@ -280,7 +280,7 @@ pub struct BuySplCompressedInstructionArgs {
 ///   21. `[writable, optional]` maker_broker_currency_ta
 ///   22. `[writable]` rent_destination
 ///   23. `[writable, signer]` rent_payer
-///   24. `[signer, optional]` cosigner (default to `TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp`)
+///   24. `[signer, optional]` cosigner
 #[derive(Clone, Debug, Default)]
 pub struct BuySplCompressedBuilder {
     fee_vault: Option<solana_program::pubkey::Pubkey>,

--- a/clients/rust/src/generated/instructions/buy_wns.rs
+++ b/clients/rust/src/generated/instructions/buy_wns.rs
@@ -229,7 +229,7 @@ pub struct BuyWnsInstructionArgs {
 ///   17. `[optional]` wns_program (default to `wns1gDLt8fgLcGhWi5MqAqgXpwEP1JftKE9eZnXS1HM`)
 ///   18. `[optional]` distribution_program (default to `diste3nXmK7ddDTs1zb6uday6j4etCa9RChD8fJ1xay`)
 ///   19. `[]` extra_metas
-///   20. `[signer, optional]` cosigner (default to `TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp`)
+///   20. `[signer, optional]` cosigner
 #[derive(Clone, Debug, Default)]
 pub struct BuyWnsBuilder {
     fee_vault: Option<solana_program::pubkey::Pubkey>,

--- a/clients/rust/src/generated/instructions/list_compressed.rs
+++ b/clients/rust/src/generated/instructions/list_compressed.rs
@@ -166,7 +166,7 @@ pub struct ListCompressedInstructionArgs {
 ///   8. `[optional]` marketplace_program (default to `TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp`)
 ///   9. `[writable]` list_state
 ///   10. `[writable, signer]` rent_payer
-///   11. `[signer, optional]` cosigner (default to `TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp`)
+///   11. `[signer, optional]` cosigner
 #[derive(Clone, Debug, Default)]
 pub struct ListCompressedBuilder {
     tree_authority: Option<solana_program::pubkey::Pubkey>,

--- a/scripts/generate-clients.mjs
+++ b/scripts/generate-clients.mjs
@@ -211,13 +211,13 @@ kinobi.update(
 // Update instructions.
 kinobi.update(
   k.updateInstructionsVisitor({
-    // Manually set cosigner to be true if it's passed in.
+    // set cosigner to be an optional signer
+    // don't (!) set a defaultValue, since this value will end up not being omitted 
+    // in getAccountMetaFactory and will lead to the ix failing
     buyLegacy: {
       accounts: {
         cosigner: {
-          defaultValue: k.publicKeyValueNode(
-            "TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp",
-          ),
+          isOptional: true,
           isSigner: true,
         },
       },
@@ -225,50 +225,40 @@ kinobi.update(
     buy: {
       accounts: {
         cosigner: {
-          defaultValue: k.publicKeyValueNode(
-            "TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp",
-          ),
           isSigner: true,
+          isOptional: true,
         },
       },
     },
     list: {
       accounts: {
         cosigner: {
-          defaultValue: k.publicKeyValueNode(
-            "TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp",
-          ),
           isSigner: true,
+          isOptional: true,
         },
       },
     },
     buySpl: {
       accounts: {
         cosigner: {
-          defaultValue: k.publicKeyValueNode(
-            "TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp",
-          ),
           isSigner: true,
+          isOptional: true,
         },
       },
     },
     buyCore: {
       accounts: {
         cosigner: {
-          defaultValue: k.publicKeyValueNode(
-            "TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp",
-          ),
           isSigner: true,
+          isOptional: true,
         },
       },
     },
     buyWns: {
       accounts: {
         cosigner: {
-          defaultValue: k.publicKeyValueNode(
-            "TCMPhJdwDryooaGtiocG1u3xcYbRpiJzb283XfCZsDp",
-          ),
           isSigner: true,
+          isOptional: true,
         },
       },
     },


### PR DESCRIPTION
- removes default value for cosigner where the cosigner is an optional acc, previously we've set the default value to the program ID, but this address did NOT get omitted when constructing the ix, so the ix would fail because it would be interpreted as first proof account for compressed ixs

e.g. https://explorer.solana.com/tx/5v5sdYgHPNQPkuk4X9cMtu2n9h6D4mMDYLZ5gNqjb9j2cGbsYjLkKdveWfB9Gi9NEaKKDpk8fQSDGJW7Ne1vswsy