### PR TITLE
Leant/minor client fixes

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensor-foundation/marketplace",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "description": "Your one-stop-shop for your NFT needs.",
   "sideEffects": false,
   "module": "./dist/src/index.mjs",

--- a/clients/js/src/generated/instructions/buySplCompressed.ts
+++ b/clients/js/src/generated/instructions/buySplCompressed.ts
@@ -58,6 +58,7 @@ import {
   resolveTakerBrokerCurrencyAta,
   resolveTreeAuthorityPda,
 } from '@tensor-foundation/resolvers';
+import { resolveProofPath } from '../../hooked';
 import { TENSOR_MARKETPLACE_PROGRAM_ADDRESS } from '../programs';
 import {
   expectSome,
@@ -282,6 +283,8 @@ export function getBuySplCompressedInstructionDataCodec(): Codec<
 export type BuySplCompressedInstructionExtraArgs = {
   creators: Array<Address>;
   creatorsCurrencyTa: Array<Address>;
+  proof?: Array<Address>;
+  canopyDepth?: number;
 };
 
 export type BuySplCompressedAsyncInput<
@@ -347,6 +350,8 @@ export type BuySplCompressedAsyncInput<
   optionalRoyaltyPct?: BuySplCompressedInstructionDataArgs['optionalRoyaltyPct'];
   creators: BuySplCompressedInstructionExtraArgs['creators'];
   creatorsCurrencyTa?: BuySplCompressedInstructionExtraArgs['creatorsCurrencyTa'];
+  proof?: BuySplCompressedInstructionExtraArgs['proof'];
+  canopyDepth?: BuySplCompressedInstructionExtraArgs['canopyDepth'];
 };
 
 export async function getBuySplCompressedInstructionAsync<
@@ -584,6 +589,12 @@ export async function getBuySplCompressedInstructionAsync<
   if (!args.creatorsCurrencyTa) {
     args.creatorsCurrencyTa = await resolveCreatorsCurrencyAta(resolverScope);
   }
+  if (!args.proof) {
+    args.proof = [];
+  }
+  if (!args.canopyDepth) {
+    args.canopyDepth = 0;
+  }
 
   // Remaining accounts.
   const remainingAccounts: IAccountMeta[] = [
@@ -595,6 +606,7 @@ export async function getBuySplCompressedInstructionAsync<
       address,
       role: AccountRole.WRITABLE,
     })),
+    ...resolveProofPath(resolverScope),
   ];
 
   const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');
@@ -726,6 +738,8 @@ export type BuySplCompressedInput<
   optionalRoyaltyPct?: BuySplCompressedInstructionDataArgs['optionalRoyaltyPct'];
   creators: BuySplCompressedInstructionExtraArgs['creators'];
   creatorsCurrencyTa?: BuySplCompressedInstructionExtraArgs['creatorsCurrencyTa'];
+  proof?: BuySplCompressedInstructionExtraArgs['proof'];
+  canopyDepth?: BuySplCompressedInstructionExtraArgs['canopyDepth'];
 };
 
 export function getBuySplCompressedInstruction<
@@ -870,6 +884,9 @@ export function getBuySplCompressedInstruction<
   // Original args.
   const args = { ...input };
 
+  // Resolver scope.
+  const resolverScope = { programAddress, accounts, args };
+
   // Resolve default values.
   if (!accounts.currencyTokenProgram.value) {
     accounts.currencyTokenProgram.value =
@@ -913,6 +930,12 @@ export function getBuySplCompressedInstruction<
   if (!args.nonce) {
     args.nonce = expectSome(args.index);
   }
+  if (!args.proof) {
+    args.proof = [];
+  }
+  if (!args.canopyDepth) {
+    args.canopyDepth = 0;
+  }
 
   // Remaining accounts.
   const remainingAccounts: IAccountMeta[] = [
@@ -924,6 +947,7 @@ export function getBuySplCompressedInstruction<
       address,
       role: AccountRole.WRITABLE,
     })),
+    ...resolveProofPath(resolverScope),
   ];
 
   const getAccountMeta = getAccountMetaFactory(programAddress, 'programId');

--- a/clients/js/src/generated/instructions/buyWnsSpl.ts
+++ b/clients/js/src/generated/instructions/buyWnsSpl.ts
@@ -242,10 +242,7 @@ export function getBuyWnsSplInstructionDataCodec(): Codec<
   );
 }
 
-export type BuyWnsSplInstructionExtraArgs = {
-  collection: Address;
-  paymentMint?: Address;
-};
+export type BuyWnsSplInstructionExtraArgs = { collection: Address };
 
 export type BuyWnsSplAsyncInput<
   TAccountFeeVault extends string = string,
@@ -311,7 +308,6 @@ export type BuyWnsSplAsyncInput<
   cosigner?: TransactionSigner<TAccountCosigner>;
   maxAmount: BuyWnsSplInstructionDataArgs['maxAmount'];
   collection: BuyWnsSplInstructionExtraArgs['collection'];
-  paymentMint?: BuyWnsSplInstructionExtraArgs['paymentMint'];
 };
 
 export async function getBuyWnsSplInstructionAsync<
@@ -571,10 +567,6 @@ export async function getBuyWnsSplInstructionAsync<
       ...(await resolveWnsApprovePda(resolverScope)),
     };
   }
-  if (!args.paymentMint) {
-    args.paymentMint =
-      '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
-  }
   if (!accounts.distribution.value) {
     accounts.distribution = {
       ...accounts.distribution,
@@ -739,7 +731,6 @@ export type BuyWnsSplInput<
   cosigner?: TransactionSigner<TAccountCosigner>;
   maxAmount: BuyWnsSplInstructionDataArgs['maxAmount'];
   collection: BuyWnsSplInstructionExtraArgs['collection'];
-  paymentMint?: BuyWnsSplInstructionExtraArgs['paymentMint'];
 };
 
 export function getBuyWnsSplInstruction<
@@ -933,10 +924,6 @@ export function getBuyWnsSplInstruction<
   }
   if (!accounts.systemProgram.value) {
     accounts.systemProgram.value =
-      '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
-  }
-  if (!args.paymentMint) {
-    args.paymentMint =
       '11111111111111111111111111111111' as Address<'11111111111111111111111111111111'>;
   }
   if (!accounts.wnsProgram.value) {

--- a/clients/js/test/compressed/buySpl.test.ts
+++ b/clients/js/test/compressed/buySpl.test.ts
@@ -156,6 +156,7 @@ test('it can buy a listed compressed nft using a SPL token as currency', async (
     creators: meta.creators.map((creator) => creator.address),
     makerBroker: makerBroker.address,
     takerBroker: takerBroker.address,
+    proof,
   });
 
   await pipe(
@@ -294,6 +295,7 @@ test('it can buy a listed compressed nft using a T22 token as currency', async (
     sellerFeeBasisPoints: meta.sellerFeeBasisPoints,
     currencyTokenProgram: TOKEN22_PROGRAM_ID,
     creators: meta.creators.map((creator) => creator.address),
+    proof,
   });
 
   await pipe(

--- a/clients/rust/Cargo.lock
+++ b/clients/rust/Cargo.lock
@@ -5033,7 +5033,7 @@ dependencies = [
 
 [[package]]
 name = "tensor-marketplace"
-version = "0.6.0"
+version = "0.6.2"
 dependencies = [
  "anchor-lang",
  "assert_matches",

--- a/clients/rust/Cargo.lock
+++ b/clients/rust/Cargo.lock
@@ -5033,7 +5033,7 @@ dependencies = [
 
 [[package]]
 name = "tensor-marketplace"
-version = "0.6.2"
+version = "0.6.1"
 dependencies = [
  "anchor-lang",
  "assert_matches",

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tensor-marketplace"
-version = "0.6.2"
+version = "0.6.1"
 description = "Client crate for the Tensor Foundation marketplace program."
 repository = "https://github.com/tensor-foundation/marketplace"
 homepage = "https://github.com/tensor-foundation/marketplace"

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tensor-marketplace"
-version = "0.6.1"
+version = "0.6.2"
 description = "Client crate for the Tensor Foundation marketplace program."
 repository = "https://github.com/tensor-foundation/marketplace"
 homepage = "https://github.com/tensor-foundation/marketplace"

--- a/scripts/codama/compressed-instructions.cjs
+++ b/scripts/codama/compressed-instructions.cjs
@@ -170,6 +170,18 @@ module.exports = function visitor(options) {
                 ],
               }),
             },
+            proof: {
+              type: c.arrayTypeNode(
+                c.publicKeyTypeNode(),
+                c.prefixedCountNode(c.numberTypeNode("u32")),
+              ),
+              defaultValue: c.arrayValueNode([]),
+            },
+            canopyDepth: {
+              type: c.numberTypeNode("u8"),
+              defaultValue: c.numberValueNode(0),
+              isOptional: true,
+            },
           },
           remainingAccounts: [
             c.instructionRemainingAccountsNode(
@@ -183,6 +195,17 @@ module.exports = function visitor(options) {
               c.argumentValueNode("creatorsCurrencyTa"),
               {
                 isWritable: true,
+                isOptional: true,
+              },
+            ),
+            c.instructionRemainingAccountsNode(
+              c.resolverValueNode("resolveProofPath", {
+                dependsOn: [
+                  c.argumentValueNode("proof"),
+                  c.argumentValueNode("canopyDepth"),
+                ],
+              }),
+              {
                 isOptional: true,
               },
             ),
@@ -367,6 +390,7 @@ module.exports = function visitor(options) {
                 }),
               ],
               remainingAccounts: [
+                ...(node.remainingAccounts || []),
                 c.instructionRemainingAccountsNode(
                   c.resolverValueNode("resolveCreatorPath", {
                     dependsOn: [c.argumentValueNode("creators")],

--- a/scripts/codama/wns-instructions.cjs
+++ b/scripts/codama/wns-instructions.cjs
@@ -198,7 +198,7 @@ module.exports = function visitor(options) {
               defaultValue: c.resolverValueNode("resolveWnsDistributionPda", {
                 dependsOn: [
                   c.argumentValueNode("collection"),
-                  c.argumentValueNode("paymentMint"),
+                  c.accountValueNode("currency"),
                 ],
               }),
             },
@@ -229,12 +229,6 @@ module.exports = function visitor(options) {
           arguments: {
             collection: {
               type: c.publicKeyTypeNode(),
-            },
-            paymentMint: {
-              type: c.publicKeyTypeNode(),
-              defaultValue: c.publicKeyValueNode(
-                "11111111111111111111111111111111",
-              ),
             },
           },
         },


### PR DESCRIPTION
- adds proof/canopyDepth args / rem accs to buySplCompressed client route
- removes redundant paymentMint for buyWnsSpl (uses currency directly for distribution PDA derivation instead)
- regens cargo.lock (forgot in last PR)