### PR TITLE
always resolve edition acc (seed check)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @richardwu @samuelvanderwaal
+* @richardwu @nftechie @leantOnSol

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensor-foundation/marketplace",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "description": "Your one-stop-shop for your NFT needs.",
   "sideEffects": false,
   "module": "./dist/src/index.mjs",

--- a/clients/js/src/generated/instructions/buyLegacy.ts
+++ b/clients/js/src/generated/instructions/buyLegacy.ts
@@ -49,7 +49,6 @@ import {
   resolveAuthorizationRulesProgramFromTokenStandard,
   resolveBuyerAta,
   resolveBuyerTokenRecordFromTokenStandard,
-  resolveEditionFromTokenStandard,
   resolveFeeVaultPdaFromListState,
   resolveListAta,
   resolveListTokenRecordFromTokenStandard,
@@ -57,6 +56,7 @@ import {
   resolveSysvarInstructionsFromTokenStandard,
   resolveTokenMetadataProgramFromTokenStandard,
 } from '@tensor-foundation/resolvers';
+import { resolveEdition } from '../../hooked';
 import { findListStatePda } from '../pdas';
 import { TENSOR_MARKETPLACE_PROGRAM_ADDRESS } from '../programs';
 import {
@@ -519,7 +519,7 @@ export async function getBuyLegacyInstructionAsync<
   if (!accounts.edition.value) {
     accounts.edition = {
       ...accounts.edition,
-      ...(await resolveEditionFromTokenStandard(resolverScope)),
+      ...(await resolveEdition(resolverScope)),
     };
   }
   if (!accounts.buyerTokenRecord.value) {

--- a/clients/js/src/generated/instructions/buyLegacySpl.ts
+++ b/clients/js/src/generated/instructions/buyLegacySpl.ts
@@ -51,7 +51,6 @@ import {
   resolveBuyerAta,
   resolveBuyerTokenRecordFromTokenStandard,
   resolveCreatorsCurrencyAta,
-  resolveEditionFromTokenStandard,
   resolveFeeVaultCurrencyAta,
   resolveFeeVaultPdaFromListState,
   resolveListAta,
@@ -62,6 +61,7 @@ import {
   resolveSysvarInstructionsFromTokenStandard,
   resolveTokenMetadataProgramFromTokenStandard,
 } from '@tensor-foundation/resolvers';
+import { resolveEdition } from '../../hooked';
 import { findListStatePda } from '../pdas';
 import { TENSOR_MARKETPLACE_PROGRAM_ADDRESS } from '../programs';
 import {
@@ -605,7 +605,7 @@ export async function getBuyLegacySplInstructionAsync<
   if (!accounts.edition.value) {
     accounts.edition = {
       ...accounts.edition,
-      ...(await resolveEditionFromTokenStandard(resolverScope)),
+      ...(await resolveEdition(resolverScope)),
     };
   }
   if (!accounts.buyerTokenRecord.value) {

--- a/clients/js/src/generated/instructions/closeExpiredListingLegacy.ts
+++ b/clients/js/src/generated/instructions/closeExpiredListingLegacy.ts
@@ -41,7 +41,6 @@ import {
 } from '@tensor-foundation/mpl-token-metadata';
 import {
   resolveAuthorizationRulesProgramFromTokenStandard,
-  resolveEditionFromTokenStandard,
   resolveListAta,
   resolveListTokenRecordFromTokenStandard,
   resolveMetadata,
@@ -50,6 +49,7 @@ import {
   resolveSysvarInstructionsFromTokenStandard,
   resolveTokenMetadataProgramFromTokenStandard,
 } from '@tensor-foundation/resolvers';
+import { resolveEdition } from '../../hooked';
 import { findListStatePda } from '../pdas';
 import { TENSOR_MARKETPLACE_PROGRAM_ADDRESS } from '../programs';
 import {
@@ -445,7 +445,7 @@ export async function getCloseExpiredListingLegacyInstructionAsync<
   if (!accounts.edition.value) {
     accounts.edition = {
       ...accounts.edition,
-      ...(await resolveEditionFromTokenStandard(resolverScope)),
+      ...(await resolveEdition(resolverScope)),
     };
   }
   if (!accounts.ownerTokenRecord.value) {

--- a/clients/js/src/generated/instructions/delistLegacy.ts
+++ b/clients/js/src/generated/instructions/delistLegacy.ts
@@ -41,7 +41,6 @@ import {
 } from '@tensor-foundation/mpl-token-metadata';
 import {
   resolveAuthorizationRulesProgramFromTokenStandard,
-  resolveEditionFromTokenStandard,
   resolveListAta,
   resolveListTokenRecordFromTokenStandard,
   resolveMetadata,
@@ -50,6 +49,7 @@ import {
   resolveSysvarInstructionsFromTokenStandard,
   resolveTokenMetadataProgramFromTokenStandard,
 } from '@tensor-foundation/resolvers';
+import { resolveEdition } from '../../hooked';
 import { findListStatePda } from '../pdas';
 import { TENSOR_MARKETPLACE_PROGRAM_ADDRESS } from '../programs';
 import {
@@ -446,7 +446,7 @@ export async function getDelistLegacyInstructionAsync<
   if (!accounts.edition.value) {
     accounts.edition = {
       ...accounts.edition,
-      ...(await resolveEditionFromTokenStandard(resolverScope)),
+      ...(await resolveEdition(resolverScope)),
     };
   }
   if (!accounts.ownerTokenRecord.value) {

--- a/clients/js/src/generated/instructions/listLegacy.ts
+++ b/clients/js/src/generated/instructions/listLegacy.ts
@@ -46,7 +46,6 @@ import {
 } from '@tensor-foundation/mpl-token-metadata';
 import {
   resolveAuthorizationRulesProgramFromTokenStandard,
-  resolveEditionFromTokenStandard,
   resolveListAta,
   resolveListTokenRecordFromTokenStandard,
   resolveMetadata,
@@ -55,6 +54,7 @@ import {
   resolveSysvarInstructionsFromTokenStandard,
   resolveTokenMetadataProgramFromTokenStandard,
 } from '@tensor-foundation/resolvers';
+import { resolveEdition } from '../../hooked';
 import { findListStatePda } from '../pdas';
 import { TENSOR_MARKETPLACE_PROGRAM_ADDRESS } from '../programs';
 import {
@@ -473,7 +473,7 @@ export async function getListLegacyInstructionAsync<
   if (!accounts.edition.value) {
     accounts.edition = {
       ...accounts.edition,
-      ...(await resolveEditionFromTokenStandard(resolverScope)),
+      ...(await resolveEdition(resolverScope)),
     };
   }
   if (!accounts.ownerTokenRecord.value) {

--- a/clients/js/src/generated/instructions/takeBidLegacy.ts
+++ b/clients/js/src/generated/instructions/takeBidLegacy.ts
@@ -50,7 +50,6 @@ import {
 import {
   resolveAuthorizationRulesProgramFromTokenStandard,
   resolveBidTokenRecordFromTokenStandard,
-  resolveEditionFromTokenStandard,
   resolveFeeVaultPdaFromBidState,
   resolveMetadata,
   resolveOwnerAta,
@@ -60,6 +59,7 @@ import {
   resolveSysvarInstructionsFromTokenStandard,
   resolveTokenMetadataProgramFromTokenStandard,
 } from '@tensor-foundation/resolvers';
+import { resolveEdition } from '../../hooked';
 import { findBidStatePda, findBidTaPda } from '../pdas';
 import { TENSOR_MARKETPLACE_PROGRAM_ADDRESS } from '../programs';
 import {
@@ -576,7 +576,7 @@ export async function getTakeBidLegacyInstructionAsync<
   if (!accounts.edition.value) {
     accounts.edition = {
       ...accounts.edition,
-      ...(await resolveEditionFromTokenStandard(resolverScope)),
+      ...(await resolveEdition(resolverScope)),
     };
   }
   if (!accounts.sellerTokenRecord.value) {

--- a/clients/js/src/hooked/resolvers.ts
+++ b/clients/js/src/hooked/resolvers.ts
@@ -119,9 +119,9 @@ export const resolveEdition = async ({
 }: {
   accounts: Record<string, ResolvedAccount>;
 }): Promise<Partial<{ value: ProgramDerivedAddress | null }>> => {
-      return {
-        value: await findEditionPda({
-          mint: expectAddress(accounts.mint?.value),
-        }),
-      };
+  return {
+    value: await findEditionPda({
+      mint: expectAddress(accounts.mint?.value),
+    }),
+  };
 };

--- a/clients/js/src/hooked/resolvers.ts
+++ b/clients/js/src/hooked/resolvers.ts
@@ -1,6 +1,7 @@
 import {
   Address,
   IAccountMeta,
+  ProgramDerivedAddress,
   ProgramDerivedAddressBump,
   TransactionSigner,
   generateKeyPair,
@@ -13,6 +14,7 @@ import {
   expectSome,
   isTransactionSigner,
 } from '../generated/shared';
+import { findEditionPda } from '@tensor-foundation/resolvers';
 
 export const resolveBidIdOnCreate = async ({
   args,
@@ -110,4 +112,16 @@ export const resolveRemainingSignerWithSellerOrDelegate = ({
   throw new Error(
     'Either seller or delegate has to be provided as TransactionSigner.'
   );
+};
+
+export const resolveEdition = async ({
+  accounts,
+}: {
+  accounts: Record<string, ResolvedAccount>;
+}): Promise<Partial<{ value: ProgramDerivedAddress | null }>> => {
+      return {
+        value: await findEditionPda({
+          mint: expectAddress(accounts.mint?.value),
+        }),
+      };
 };

--- a/scripts/codama/legacy-instructions.cjs
+++ b/scripts/codama/legacy-instructions.cjs
@@ -53,7 +53,7 @@ module.exports = function visitor(options) {
             },
             edition: {
               defaultValue: c.resolverValueNode(
-                "resolveEditionFromTokenStandard",
+                "resolveEdition",
                 {
                     dependsOn: [
                     c.accountValueNode("mint"),
@@ -148,7 +148,7 @@ module.exports = function visitor(options) {
             },
             edition: {
               defaultValue: c.resolverValueNode(
-                "resolveEditionFromTokenStandard",
+                "resolveEdition",
                 {
                     dependsOn: [
                     c.accountValueNode("mint"),
@@ -312,7 +312,7 @@ module.exports = function visitor(options) {
             },
             edition: {
               defaultValue: c.resolverValueNode(
-                "resolveEditionFromTokenStandard",
+                "resolveEdition",
                 {
                     dependsOn: [
                     c.accountValueNode("mint"),
@@ -390,7 +390,7 @@ module.exports = function visitor(options) {
             },
             edition: {
               defaultValue: c.resolverValueNode(
-                "resolveEditionFromTokenStandard",
+                "resolveEdition",
                 {
                     dependsOn: [
                     c.accountValueNode("mint"),
@@ -465,7 +465,7 @@ module.exports = function visitor(options) {
             },
             edition: {
               defaultValue: c.resolverValueNode(
-                "resolveEditionFromTokenStandard",
+                "resolveEdition",
                 {
                     dependsOn: [
                     c.accountValueNode("mint"),
@@ -566,7 +566,7 @@ module.exports = function visitor(options) {
             },
             edition: {
               defaultValue: c.resolverValueNode(
-                "resolveEditionFromTokenStandard",
+                "resolveEdition",
                 {
                     dependsOn: [
                     c.accountValueNode("mint"),

--- a/scripts/generate-clients.mjs
+++ b/scripts/generate-clients.mjs
@@ -528,7 +528,7 @@ codama.accept(
         resolveOwnerTokenRecordFromTokenStandard: '@tensor-foundation/resolvers',
         resolveSellerTokenRecordFromTokenStandard: '@tensor-foundation/resolvers',
         resolveBuyerTokenRecordFromTokenStandard: '@tensor-foundation/resolvers',
-        resolveEditionFromTokenStandard: '@tensor-foundation/resolvers',
+        resolveEdition: '../../hooked',
         resolveDistributionCurrencyAta: '@tensor-foundation/resolvers',
       },
       definedTypes: {
@@ -556,7 +556,7 @@ codama.accept(
       "resolveSellerTokenRecordFromTokenStandard",
       "resolveBidTokenRecordFromTokenStandard",
       "resolveMetadata",
-      "resolveEditionFromTokenStandard",
+      "resolveEdition",
       "resolveWnsApprovePda",
       "resolveWnsDistributionPda",
       "resolveWnsExtraAccountMetasPda",


### PR DESCRIPTION
- prev: when edition not passed in for fungibles, seed check would fail (even if edition acc doesn't need to be initialized), now: fix client resolvers to always resolve edition independent of tokenStandard

also:
- adds @nftechie and myself as codeowners, remove sam